### PR TITLE
Drop ruby 2.6 and 2.7 support

### DIFF
--- a/.github/workflows/rubygems.yml
+++ b/.github/workflows/rubygems.yml
@@ -27,8 +27,6 @@ jobs:
           - { name: Windows, value: windows-2022 }
 
         ruby:
-          - { name: "2.6", value: 2.6.10 }
-          - { name: "2.7", value: 2.7.8 }
           - { name: "3.0", value: 3.0.6 }
           - { name: "3.1", value: 3.1.4 }
           - { name: "3.2", value: 3.2.2 }

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ require: rubocop-performance
 
 AllCops:
   DisabledByDefault: true
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 3.0
   Exclude:
     - pkg/**/*
     - tmp/**/*

--- a/rubygems-generate_index.gemspec
+++ b/rubygems-generate_index.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
     "CODE_OF_CONDUCT.md"
   ]
 
-  s.required_ruby_version = Gem::Requirement.new(">= 2.6.0")
+  s.required_ruby_version = Gem::Requirement.new(">= 3.0.0")
   s.required_rubygems_version = Gem::Requirement.new(">= 0")
 
   s.add_dependency "compact_index", "~> 0.14.0"


### PR DESCRIPTION
Mirroring the change to rubygems in https://github.com/rubygems/rubygems/pull/7116
