### PR TITLE
Skip to spell check CODE_OF_CONDUCT.md

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -2,4 +2,4 @@
 check-filenames=
 check-hidden=
 ignore-words=.codespellignore
-skip=*.pem,.git,man,vcr_cassettes,vendor
+skip=CODE_OF_CONDUCT.md,*.pem,.git,man,vcr_cassettes,vendor


### PR DESCRIPTION
## What?

The current codespell detect spell miss from `CODE_OF_CONDUCT.md`. But it is upstream ploblem. 

https://github.com/rubygems/rubygems-generate_index/actions/runs/9453953833/job/26040427992#step:4:17

I skip that file.



## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
