### PR TITLE
Don't include development dependencies in info files

### DIFF
--- a/lib/rubygems/indexer.rb
+++ b/lib/rubygems/indexer.rb
@@ -574,7 +574,7 @@ class Gem::Indexer
         spec.platform.to_s,
         checksum,
         nil, # info_checksum
-        spec.dependencies.map {|d| CompactIndex::Dependency.new(d.name, d.requirement.to_s) },
+        spec.dependencies.select(&:runtime?).map {|d| CompactIndex::Dependency.new(d.name, d.requirement.to_s) },
         spec.required_ruby_version&.to_s,
         spec.required_rubygems_version&.to_s
       )

--- a/lib/rubygems/indexer.rb
+++ b/lib/rubygems/indexer.rb
@@ -574,7 +574,7 @@ class Gem::Indexer
         spec.platform.to_s,
         checksum,
         nil, # info_checksum
-        spec.dependencies.select(&:runtime?).map {|d| CompactIndex::Dependency.new(d.name, d.requirement.to_s) },
+        spec.runtime_dependencies.map {|d| CompactIndex::Dependency.new(d.name, d.requirement.to_s) },
         spec.required_ruby_version&.to_s,
         spec.required_rubygems_version&.to_s
       )

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -948,6 +948,9 @@ Also, a list:
   * An entry that\'s actually kind of sort
   * an entry that\'s really long, which will probably get wrapped funny.  That's ok, somebody wasn't thinking straight when they made it more than eighty characters.
       DESC
+
+      s.add_runtime_dependency "b"
+      s.add_development_dependency "x"
     end
 
     init = proc do |s|

--- a/test/rubygems/test_gem_indexer.rb
+++ b/test/rubygems/test_gem_indexer.rb
@@ -138,7 +138,7 @@ class TestGemIndexer < Gem::TestCase
 
     assert_equal <<~INFO_FILE, File.read(File.join(@indexer.directory, "info", "a"))
       ---
-      1 |checksum:#{file_sha256(File.join(gems, "a-1.gem"))}
+      1 b:>= 0|checksum:#{file_sha256(File.join(gems, "a-1.gem"))}
       2 |checksum:#{file_sha256(File.join(gems, "a-2.gem"))}
       3.a |checksum:#{file_sha256(File.join(gems, "a-3.a.gem"))},rubygems:> 1.3.1
     INFO_FILE


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

#22 -- clients are forced to download (and resolve) development dependencies of gems served with these indexes.

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

Filter out development dependencies in the info file. I noticed that this is what RubyGems.org does, for example: https://rubygems.org/info/graphql (doesn't have development_dependencies)

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

**I noticed that some tests on master are already failing on `rubygems:> 1.3.1` -- I didn't attempt to fix those.**