### PR TITLE
Use default permissions for info/ dir

### DIFF
--- a/lib/rubygems/indexer.rb
+++ b/lib/rubygems/indexer.rb
@@ -216,7 +216,7 @@ class Gem::Indexer
 
     Gem.time "Generated compact index files" do
       info_dir = File.join(@directory, "info")
-      FileUtils.mkdir_p info_dir, :mode => 0o700
+      FileUtils.mkdir_p info_dir
 
       gems.each do |gem|
         info = CompactIndex.info(gem.versions)

--- a/test/rubygems/test_gem_indexer.rb
+++ b/test/rubygems/test_gem_indexer.rb
@@ -368,6 +368,10 @@ class TestGemIndexer < Gem::TestCase
     util_remove_gem sys_gem
   end
 
+  def file_permissions_for(path)
+    format("%o", File.stat(path).mode)
+  end
+
   def test_update_index
     use_ui @ui do
       @indexer.generate_index
@@ -377,8 +381,12 @@ class TestGemIndexer < Gem::TestCase
     marshal_quickdir = File.join quickdir, "Marshal.#{@marshal_version}"
     infodir = File.join @indexerdir, "info"
 
+    assert_directory_exists(infodir)
+    assert_equal file_permissions_for(infodir), "40755"
     assert_directory_exists quickdir
+    assert_equal file_permissions_for(quickdir), "40755"
     assert_directory_exists marshal_quickdir
+    assert_equal file_permissions_for(marshal_quickdir), "40755"
 
     compact_index_versions_path = File.join(@indexerdir, "versions")
     versions_file_created_at = CompactIndex::VersionsFile.new(compact_index_versions_path).updated_at


### PR DESCRIPTION


## What was the end-user or developer problem that led to this PR?

#25

## What is your fix for the problem, implemented in this PR?

I found that by removing the customized `:mode => ...`, `info/` would have the same permissions as the other directories created by the index 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
