### PR TITLE
Fix Windows CI with bundler-cache by ruby/setup-ruby

### DIFF
--- a/.github/workflows/rubygems.yml
+++ b/.github/workflows/rubygems.yml
@@ -28,7 +28,7 @@ jobs:
 
         ruby:
           - { name: "3.0", value: 3.0.7 }
-          - { name: "3.1", value: 3.1.5 }
+          - { name: "3.1", value: 3.1.7 }
           - { name: "3.2", value: 3.2.4 }
           - { name: "3.3", value: 3.3.3 }
 
@@ -51,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Setup ruby
-        uses: ruby/setup-ruby@97e35c5302afcf3f5ac1df3fca9343d32536b286 # v1.184.0
+        uses: ruby/setup-ruby@efbf473cab83af4468e8606cc33eca9281bb213f # v1.256.0
         with:
           ruby-version: ${{ matrix.ruby.value }}
           bundler-cache: true

--- a/.github/workflows/rubygems.yml
+++ b/.github/workflows/rubygems.yml
@@ -50,25 +50,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: Setup ruby (Ubuntu/macOS)
+      - name: Setup ruby
         uses: ruby/setup-ruby@97e35c5302afcf3f5ac1df3fca9343d32536b286 # v1.184.0
         with:
           ruby-version: ${{ matrix.ruby.value }}
           bundler-cache: true
-        if: matrix.os.name != 'Windows'
-      - name: Setup ruby (Windows)
-        uses: ruby/setup-ruby-pkgs@1493c009477b19efcb54cfaf72b5f9d1fd6ba86c # v1.33.2
-        with:
-          ruby-version: ${{ matrix.ruby.value }}
-          bundler-cache: true
-          mingw: clang
-        if: matrix.os.name == 'Windows'
-      - name: Configure bindgen
-        shell: pwsh
-        run: |
-          echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
-          echo "BINDGEN_EXTRA_CLANG_ARGS=$((gcm clang).source -replace "bin\clang.exe","include")" >> $env:GITHUB_ENV
-        if: matrix.ruby.name == 'mswin'
       - name: Run Test
         run: bundle exec rake test
         if: "!startsWith(matrix.ruby.name, 'truffleruby') && !startsWith(matrix.ruby.name, 'jruby')"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Fix https://github.com/rubygems/rubygems-generate_index/actions/runs/17058177957/job/48359674632?pr=77

## What is your fix for the problem, implemented in this PR?

We don't use bindgen for cargo builder in this repository. I removed that toolchain and update to the latest version of `ruby/setup-ruby`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
