### PR TITLE
Include prerelease gems in compact index during incremental update

### DIFF
--- a/lib/rubygems/indexer.rb
+++ b/lib/rubygems/indexer.rb
@@ -450,7 +450,7 @@ class Gem::Indexer
 
     if @build_compact
       Gem.time "Updated compact index files" do
-        files += update_compact_index released, @dest_directory, @directory
+        files += update_compact_index specs, @dest_directory, @directory
       end
     end
 

--- a/test/rubygems/test_gem_indexer.rb
+++ b/test/rubygems/test_gem_indexer.rb
@@ -459,10 +459,11 @@ class TestGemIndexer < Gem::TestCase
         1 |checksum:#{file_sha256(File.join(gems, "e-1.gem"))}
       INFO_FILE
 
-      d_info = File.read(File.join(infodir, "d"))
-      assert d_info.start_with?(info_d_file), "info/d should preserve original content"
-      assert_match(/^2\.1 \|checksum:#{Regexp.escape(file_sha256(File.join(gems, "d-2.1.gem")))}$/, d_info)
-      assert_match(/^2\.2\.a \|checksum:#{Regexp.escape(file_sha256(File.join(gems, "d-2.2.a.gem")))}/, d_info)
+      assert_equal <<~INFO_FILE, File.read(File.join(infodir, "d"))
+        #{info_d_file.chomp}
+        2.1 |checksum:#{file_sha256(File.join(gems, "d-2.1.gem"))}
+        2.2.a |checksum:#{file_sha256(File.join(gems, "d-2.2.a.gem"))}
+      INFO_FILE
 
       assert_equal <<~VERSIONS_FILE, File.read(File.join(@indexerdir, "versions"))
         #{versions_file.chomp}

--- a/test/rubygems/test_gem_indexer.rb
+++ b/test/rubygems/test_gem_indexer.rb
@@ -459,14 +459,14 @@ class TestGemIndexer < Gem::TestCase
         1 |checksum:#{file_sha256(File.join(gems, "e-1.gem"))}
       INFO_FILE
 
-      assert_equal <<~INFO_FILE, File.read(File.join(infodir, "d"))
-        #{info_d_file.chomp}
-        2.1 |checksum:#{file_sha256(File.join(gems, "d-2.1.gem"))}
-      INFO_FILE
+      d_info = File.read(File.join(infodir, "d"))
+      assert d_info.start_with?(info_d_file), "info/d should preserve original content"
+      assert_match(/^2\.1 \|checksum:#{Regexp.escape(file_sha256(File.join(gems, "d-2.1.gem")))}$/, d_info)
+      assert_match(/^2\.2\.a \|checksum:#{Regexp.escape(file_sha256(File.join(gems, "d-2.2.a.gem")))}/, d_info)
 
       assert_equal <<~VERSIONS_FILE, File.read(File.join(@indexerdir, "versions"))
         #{versions_file.chomp}
-        d 2.1 #{file_md5(File.join(@indexerdir, "info", "d"))}
+        d 2.1,2.2.a #{file_md5(File.join(@indexerdir, "info", "d"))}
         e 1 #{file_md5(File.join(@indexerdir, "info", "e"))}
       VERSIONS_FILE
 

--- a/test/rubygems/test_gem_indexer.rb
+++ b/test/rubygems/test_gem_indexer.rb
@@ -462,7 +462,7 @@ class TestGemIndexer < Gem::TestCase
       assert_equal <<~INFO_FILE, File.read(File.join(infodir, "d"))
         #{info_d_file.chomp}
         2.1 |checksum:#{file_sha256(File.join(gems, "d-2.1.gem"))}
-        2.2.a |checksum:#{file_sha256(File.join(gems, "d-2.2.a.gem"))}
+        2.2.a |checksum:#{file_sha256(File.join(gems, "d-2.2.a.gem"))}#{",rubygems:> 1.3.1" if Gem::VERSION < "3.5.0"}
       INFO_FILE
 
       assert_equal <<~VERSIONS_FILE, File.read(File.join(@indexerdir, "versions"))


### PR DESCRIPTION
## Summary

Fixes #48.

In `update_index`, the call to `update_compact_index` only received `released` specs, excluding prerelease gems from the compact index files (`versions`, `info/<gemname>`). Since `build_compact` defaults to `true` and modern Bundler prefers the compact index over legacy specs files, prerelease gems were effectively invisible after an incremental `gem generate_index --update` — even though they were correctly added to `prerelease_specs.4.8.gz`.

The fix passes all specs (both released and prerelease) to `update_compact_index`, consistent with how `build_compact_index` already handles both during a full `generate_index`.

## Changes

- `lib/rubygems/indexer.rb`: Pass `specs` instead of `released` to `update_compact_index`
- `test/rubygems/test_gem_indexer.rb`: Add assertions for prerelease gem `d-2.2.a` in compact index after `update_index`